### PR TITLE
Updated usage of fbink.fbink_cls

### DIFF
--- a/yawk.py
+++ b/yawk.py
@@ -277,7 +277,7 @@ class YAWK:
         rect.left = 0
         rect.width = 0
         rect.height = 0
-        fbink.fbink_cls(self.fbfd, self.fbink_cfg, rect)
+        fbink.fbink_cls(self.fbfd, self.fbink_cfg, rect, 0)
 
         fbink.fbink_print_image(self.fbfd, image, 0, 0, self.fbink_cfg)
 


### PR DESCRIPTION
Added the 4th dummy argument to the fbink.fbink_cls, according to the updated API of FBInk. Not sure if it is supposed to be 0 or 1, both options seem to work just fine on my kobo mini.